### PR TITLE
Bug: the voting stage continues to the result stage

### DIFF
--- a/src/server/api/match-maker.ts
+++ b/src/server/api/match-maker.ts
@@ -58,7 +58,10 @@ const matchLoop = () => {
       ee.emit(matchEvent(roomId, "stageChange"));
     }
 
-    if (room.stage === "voting" && roomAge >= CHAT_TIME_MS + VOTING_TIME_MS) {
+    if (
+      room.stage === "voting" &&
+      (room.allPlayersVoted || roomAge >= CHAT_TIME_MS + VOTING_TIME_MS)
+    ) {
       room.stage = "results";
       room.calculatePoints();
       ee.emit(matchEvent(roomId, "stageChange"));

--- a/src/server/service/match.ts
+++ b/src/server/service/match.ts
@@ -45,6 +45,8 @@ export class Match {
   stage: MatchStage = "chat";
   arePointsCalculated = false;
   playerHistoryLoaded = false;
+  allPlayersVoted = false;
+
   get id() {
     return this._id;
   }
@@ -154,6 +156,14 @@ export class Match {
       if (player.userId !== playerId) return;
       player.votes = selectedPlayerIds;
     });
+
+    this.allPlayersVoted = !this._players
+      .filter(
+        (player) =>
+          !player.isBot &&
+          this.messages.some((message) => message.sender === player.userId)
+      )
+      .some((player) => !player.votes);
   }
 
   async getPlayerPreviousMatches() {


### PR DESCRIPTION
## Description

This PR introduces logic that will make the voting stage go to the result stage when all the players have voted. It also takes in consideration when a player did not send a message in the chat and is not allowed to vote.

## Related Issues

#150
