### PR TITLE
docs(readme): add yarn install step in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ cp .env.example .env
 To build and run the application locally, run the following commands:
 
 ```sh
+yarn install
 yarn build
 yarn start
 ```


### PR DESCRIPTION
### Description
The "Building and running" section of the [readme](https://github.com/Kryha/bot-busters/blob/main/README.md?plain=1#L19) is missing `yarn install` step before `yarn build`, I added it