### PR TITLE
fix(how-to-play-page): add links

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/containers/lottie-animations/**.json

--- a/src/assets/text/how-to-play.ts
+++ b/src/assets/text/how-to-play.ts
@@ -74,7 +74,7 @@ export const howToPlay = {
       regular:
         "KYC (Know Your Customer) process required for credit eligibility via ",
       highlight: "zPass.",
-      link: "",
+      link: "https://zpass.aleo.org/",
     },
   ],
   link: {

--- a/src/components/game-rules/game-rules.tsx
+++ b/src/components/game-rules/game-rules.tsx
@@ -6,13 +6,17 @@ import { BulletPoint, type BulletPointProps } from "~/components/index.js";
 import { NumberedSection } from "~/components/numbered-text-section/index.js";
 import { styles } from "~/styles/pages/how-to-play.js";
 import { theme } from "~/styles/theme.js";
+import { useRouter } from "next/router";
+import { pages } from "~/router";
 
 /**
  * How-to-play page section with static content
  * explaining the rules of Botbusters
  */
-export const GameRules: FC = () =>
-  Object.entries(copywrite.howToPlay.numberedSection).map(
+export const GameRules: FC = () => {
+  const router = useRouter();
+
+  return Object.entries(copywrite.howToPlay.numberedSection).map(
     ([title, content], idx) => (
       <NumberedSection
         key={idx + 1}
@@ -39,7 +43,7 @@ export const GameRules: FC = () =>
               <BulletPoint key={idxList} {...propsNoText}>
                 <Typography variant="body1">
                   {text}
-                  <a href={copywrite.howToPlay.link.connectingYourWallet.link}>
+                  <a onClick={() => void router.push(pages.login)}>
                     {copywrite.howToPlay.link.connectingYourWallet.text}
                   </a>
                 </Typography>
@@ -52,3 +56,4 @@ export const GameRules: FC = () =>
       />
     ),
   );
+};

--- a/src/components/player-profiles/player-profiles.tsx
+++ b/src/components/player-profiles/player-profiles.tsx
@@ -4,6 +4,8 @@ import { Typography } from "@mui/material";
 import { text } from "~/assets/text/index.js";
 import { BulletPoint } from "~/components/index.js";
 import { theme } from "~/styles/theme.js";
+import { useRouter } from "next/router";
+import { pages } from "~/router";
 
 const sectionContent = text.howToPlay.playerProfiles;
 
@@ -11,29 +13,40 @@ const sectionContent = text.howToPlay.playerProfiles;
  * How-to-play page section with static content
  * with information about accounts
  */
-export const PlayerProfiles: FC = () => [
-  <BulletPoint key="playerProfile1">
-    <Typography variant="body1">
-      {sectionContent[0].regular}
-      <span style={{ color: theme.palette.primary.main }}>
-        {sectionContent[0].highlight}
-      </span>
-    </Typography>
-  </BulletPoint>,
-  <BulletPoint key="playerProfile2">
-    <Typography variant="body1">
-      {sectionContent[1].regular}
-      <a href="" style={{ color: theme.palette.primary.main }}>
-        {sectionContent[1].highlight}
-      </a>
-    </Typography>
-  </BulletPoint>,
-  <BulletPoint key="playerProfile3">
-    <Typography variant="body1">
-      {sectionContent[2].regular}
-      <a href="" style={{ color: theme.palette.secondary.main }}>
-        {sectionContent[2].highlight}
-      </a>
-    </Typography>
-  </BulletPoint>,
-];
+export const PlayerProfiles: FC = () => {
+  const router = useRouter();
+
+  return [
+    <BulletPoint key="playerProfile1">
+      <Typography variant="body1">
+        {sectionContent[0].regular}
+        <span style={{ color: theme.palette.primary.main }}>
+          {sectionContent[0].highlight}
+        </span>
+      </Typography>
+    </BulletPoint>,
+    <BulletPoint key="playerProfile2">
+      <Typography variant="body1">
+        {sectionContent[1].regular}
+        <a
+          onClick={() => void router.push(pages.login)}
+          style={{ color: theme.palette.primary.main }}
+        >
+          {sectionContent[1].highlight}
+        </a>
+      </Typography>
+    </BulletPoint>,
+    <BulletPoint key="playerProfile3">
+      <Typography variant="body1">
+        {sectionContent[2].regular}
+        <a
+          href={sectionContent[2].link}
+          style={{ color: theme.palette.secondary.main }}
+          target="_blank"
+        >
+          {sectionContent[2].highlight}
+        </a>
+      </Typography>
+    </BulletPoint>,
+  ];
+};

--- a/src/pages/how-to-play.tsx
+++ b/src/pages/how-to-play.tsx
@@ -1,4 +1,5 @@
 import { Stack, Typography } from "@mui/material";
+import { useRouter } from "next/router";
 import React, { type FC } from "react";
 import { text as copywrite } from "~/assets/text/index.js";
 import {
@@ -7,9 +8,13 @@ import {
   PlayerProfiles,
   PointsAndPenalties,
 } from "~/components/index.js";
+import { pages } from "~/router.js";
 import { styles } from "~/styles/pages/how-to-play.js";
 
 const HowToPlay: FC = () => {
+  const router = useRouter();
+  const redirectToLogin = () => void router.push(pages.login);
+
   const pageContent = copywrite.howToPlay;
   return (
     <Stack sx={styles.container}>
@@ -23,7 +28,7 @@ const HowToPlay: FC = () => {
         {pageContent.main[1]}
       </Typography>
       <Stack sx={styles.gameRulesSection}>
-        <GameRules />
+        <GameRules connectWalletLink={redirectToLogin} />
       </Stack>
 
       <Typography variant="h1" sx={styles.heading}>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -6,7 +6,9 @@
 }
 
 a {
-  color: #5CFF00;
+  color: #5cff00;
+  cursor: pointer;
+  text-decoration: underline;
 }
 
 /* Animations */


### PR DESCRIPTION
fixes #202 

## Description
Current How to play page is missing links.
- [x] add zPass link (target="_blank")
- [x] redirect to `/login` on "connect wallet" links
- [x] update tag style