### PR TITLE
feat(matchmaking): filter double player

### DIFF
--- a/src/pages/lobby.tsx
+++ b/src/pages/lobby.tsx
@@ -12,10 +12,13 @@ const Lobby: FC = () => {
     queueLength: 0,
   });
 
-  // TODO: consider deleting this listener and call join inside a `useEffect`
   api.lobby.onQueueUpdate.useSubscription(undefined, {
-    onStarted() {
-      join.mutate();
+    async onStarted() {
+      try {
+        await join.mutateAsync();
+      } catch (error) {
+        await push(pages.home);
+      }
     },
     onData({ playerQueuePosition, queueLength }) {
       setLobbyQueue({ playerQueuePosition, queueLength });

--- a/src/server/api/match-maker.ts
+++ b/src/server/api/match-maker.ts
@@ -16,6 +16,14 @@ export const matchEvent = (
   eventType: MatchEventType = "message",
 ) => `chat_${roomId}_${eventType}`;
 
+export const isUserPlaying = (userId: string) => {
+  for (const match of matches.values()) {
+    const isInMatch = !!match.players.find((p) => p.userId === userId);
+    if (isInMatch) return true;
+  }
+  return false;
+};
+
 const makeMatch = () => {
   const botsInMatch = 1; // TODO: use more options
   const humansInMatch = env.PLAYERS_PER_MATCH - botsInMatch;

--- a/src/server/api/match-maker.ts
+++ b/src/server/api/match-maker.ts
@@ -3,13 +3,11 @@ import { EventEmitter } from "events";
 import { MATCH_TIME_MS } from "~/constants/main.js";
 import { env } from "~/env.mjs";
 import { db } from "~/server/db/index.js";
-import { Match, leaderboard } from "~/server/service/index.js";
+import { Match, leaderboard, lobbyQueue } from "~/server/service/index.js";
 import type { MatchEventType, MatchRoom } from "~/types/index.js";
 import { insertMatches } from "~/server/db/match.js";
 
 export const ee = new EventEmitter();
-
-export const lobbyQueue: string[] = [];
 
 export const matches = new Map<string, Match>();
 
@@ -24,8 +22,8 @@ const makeMatch = () => {
 
   // TODO: Make the players per match random within the range 1-4
   // TODO: Benchmark and check what's the maximum amount of matches we can handle at a time
-  while (lobbyQueue.length >= humansInMatch) {
-    const playerIds = lobbyQueue.splice(0, humansInMatch);
+  while (lobbyQueue.queue.length >= humansInMatch) {
+    const playerIds = lobbyQueue.pickPlayers(humansInMatch);
     const match = new Match(playerIds, botsInMatch);
 
     matches.set(match.id, match);

--- a/src/server/api/routers/lobby.ts
+++ b/src/server/api/routers/lobby.ts
@@ -1,19 +1,23 @@
+import { TRPCError } from "@trpc/server";
 import { observable } from "@trpc/server/observable";
 
 import type { QueueUpdatePayload, ReadyToPlayPayload } from "~/types/index.js";
+import { lobbyQueue } from "~/server/service/index.js";
 
 import { createTRPCRouter, protectedProcedure } from "../trpc.js";
-import { ee, lobbyQueue } from "../match-maker.js";
+import { ee } from "../match-maker.js";
 
 export const lobbyRouter = createTRPCRouter({
   onQueueUpdate: protectedProcedure.subscription(({ ctx }) => {
     return observable<QueueUpdatePayload>((emit) => {
       const handleEvent = () => {
-        const playerQueuePosition = lobbyQueue.indexOf(ctx.session.user.id) + 1;
+        const playerQueuePosition = lobbyQueue.getPlayerPosition(
+          ctx.session.user.id,
+        );
         // emit data to client
         emit.next({
           playerQueuePosition,
-          queueLength: lobbyQueue.length,
+          queueLength: lobbyQueue.queue.length,
         });
       };
 
@@ -23,27 +27,25 @@ export const lobbyRouter = createTRPCRouter({
         ee.off("queueUpdate", handleEvent);
 
         const { id } = ctx.session.user;
-        const index = lobbyQueue.indexOf(id);
 
-        // If the user is in the queue, and they unsubscribe (disconnect), remove them from the queue
-        lobbyQueue.splice(index, 1);
+        lobbyQueue.leave(id);
+
         ee.emit("queueUpdate");
       };
     });
   }),
   join: protectedProcedure.mutation(({ ctx }) => {
     const { id } = ctx.session.user;
+    const joinCount = lobbyQueue.join(id);
 
-    const hasJoined = lobbyQueue.includes(id);
-
-    if (!hasJoined) {
-      lobbyQueue.push(id);
-    }
-
-    const playerQueuePosition = lobbyQueue.indexOf(ctx.session.user.id) + 1;
+    if (joinCount > 1) throw new TRPCError({ code: "FORBIDDEN" });
 
     ee.emit("queueUpdate");
-    return { playerQueuePosition, queueLength: lobbyQueue.length };
+
+    return {
+      playerQueuePosition: lobbyQueue.getPlayerPosition(id),
+      queueLength: lobbyQueue.queue.length,
+    };
   }),
 
   onReadyToPlay: protectedProcedure.subscription(({ ctx }) => {

--- a/src/server/service/index.ts
+++ b/src/server/service/index.ts
@@ -3,3 +3,4 @@ export * from "./match.js";
 export * from "./achievements.js";
 export * from "./leaderboard/index.js";
 export * from "./aleo.js";
+export * from "./lobby-queue.js";

--- a/src/server/service/lobby-queue.ts
+++ b/src/server/service/lobby-queue.ts
@@ -1,0 +1,54 @@
+class LobbyQueue {
+  private _listeners = new Map<string, number>();
+  private _queue: string[] = [];
+
+  get queue() {
+    return this._queue;
+  }
+
+  join(userId: string) {
+    const count = this._listeners.get(userId);
+    const newCount = count ? count + 1 : 1;
+
+    this._listeners.set(userId, newCount);
+
+    if (newCount === 1) {
+      this._queue.push(userId);
+    }
+
+    return newCount;
+  }
+
+  leave(userId: string) {
+    const count = this._listeners.get(userId);
+
+    if (!count) return;
+
+    if (count <= 1) {
+      this._listeners.delete(userId);
+
+      const index = this._queue.indexOf(userId);
+      this._queue.splice(index, 1);
+    } else {
+      this._listeners.set(userId, count - 1);
+    }
+  }
+
+  pickPlayers(humansInMatch: number) {
+    const ids = this._queue.splice(0, humansInMatch);
+
+    ids.forEach((id) => this._listeners.delete(id));
+
+    return ids;
+  }
+
+  getPlayerPosition(userId: string) {
+    return this._queue.indexOf(userId) + 1;
+  }
+
+  has(userId: string) {
+    return !!this._listeners.get(userId);
+  }
+}
+
+export const lobbyQueue = new LobbyQueue();


### PR DESCRIPTION
## Description

This PR prevents a user from joining more than one match a time and joining the lobby queue more than once.

## Changes

- Created lobby queue service
- Redirecting user to homepage if they already joined the queue from another window
- Redirecting user to homepage from lobby if they are already playing a match