### PR TITLE
hotfix(connect-wallet): refactor connect wallet and username ui

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,7 +20,7 @@ DATABASE_URL="postgresql://postgres:example@localhost:5432"
 APP_URL="http://localhost:3000"
 NEXT_PUBLIC_WS_URL="ws://localhost:3001"
 NEXT_PUBLIC_MOCK_AUTH="false"
-PLAYERS_PER_MATCH="2"
+PLAYERS_PER_MATCH="3"
 HUGGING_FACE_TOKEN="<your_token>"
 
 ALEO_NETWORK_URL="http://localhost:3030"

--- a/src/components/main-menu/menu-options.tsx
+++ b/src/components/main-menu/menu-options.tsx
@@ -10,6 +10,7 @@ import { pages } from "~/router.js";
 import { styles } from "./styles.js";
 import { MenuOptionsButton } from "~/components/menu-options-button/index.js";
 import { useBBWallet } from "~/service/bb-wallet.js";
+import { isVerifiedUser } from "~/utils/user.js";
 
 interface Props {
   handleClose: () => void;
@@ -18,11 +19,11 @@ interface Props {
 export const MenuOptions: FC<Props> = ({ handleClose }) => {
   const router = useRouter();
   const join = api.lobby.join.useMutation();
-  const {
-    isConnected,
-    isConnecting,
-    disconnect: disconnectWallet,
-  } = useBBWallet();
+  const { disconnect: disconnectWallet } = useBBWallet();
+
+  const user = api.user.getLoggedUser.useQuery(undefined, {
+    retry: false,
+  });
 
   const logOut = async () => {
     await signOut();
@@ -52,7 +53,7 @@ export const MenuOptions: FC<Props> = ({ handleClose }) => {
       <MenuOptionsButton onClick={() => handleNavigation(pages.howToPlay)}>
         {text.general.howToPlay}
       </MenuOptionsButton>
-      {isConnected || isConnecting ? (
+      {isVerifiedUser(user.data) ? (
         <MenuOptionsButton onClick={() => void logOut()}>
           {text.general.signOut}
         </MenuOptionsButton>

--- a/src/components/main-menu/navbar-menu.tsx
+++ b/src/components/main-menu/navbar-menu.tsx
@@ -13,15 +13,21 @@ import {
   SoundOnIcon,
   UserIcon,
 } from "~/assets/icons/index.js";
+import { api } from "~/utils/api";
 
 interface Props {
   handleClose: () => void;
   soundOn: boolean;
+  username?: string | null;
   setSoundOn: (value: boolean) => void;
 }
 
 export const NavbarMenu: FC<Props> = ({ handleClose, soundOn, setSoundOn }) => {
   const router = useRouter();
+
+  const loggedUser = api.user.getLoggedUser.useQuery(undefined, {
+    retry: false,
+  });
 
   const onSoundClick = () => {
     setSoundOn(!soundOn);
@@ -39,7 +45,7 @@ export const NavbarMenu: FC<Props> = ({ handleClose, soundOn, setSoundOn }) => {
           <UserIcon />
         </Stack>
         <Typography variant="h3" sx={styles.userNameText}>
-          {text.general.username}
+          {loggedUser.data?.username ?? text.general.username}
         </Typography>
       </Stack>
       <Button

--- a/src/components/navbar/navbar.tsx
+++ b/src/components/navbar/navbar.tsx
@@ -13,17 +13,20 @@ import { MenuButton } from "~/components/main-menu/menu-button.jsx";
 import { MainMenu } from "~/components/main-menu/index.js";
 import { pages } from "~/router.js";
 import { styles } from "./styles.js";
+import { api } from "~/utils/api.js";
 
 interface Props {
-  isVerifiedUser: boolean;
-  username?: string | null;
   open: boolean;
   setOpen: (open: boolean) => void;
 }
 
-export const Navbar: FC<Props> = ({ open, setOpen, username }) => {
+export const Navbar: FC<Props> = ({ open, setOpen }) => {
   const router = useRouter();
   const [soundOn, setSoundOn] = useState(true);
+
+  const loggedUser = api.user.getLoggedUser.useQuery(undefined, {
+    retry: false,
+  });
 
   const onSoundClick = () => {
     setSoundOn(!soundOn);
@@ -44,7 +47,7 @@ export const Navbar: FC<Props> = ({ open, setOpen, username }) => {
             <UserIcon />
           </Stack>
           <Typography variant="h3" sx={styles.userNameText}>
-            {username ?? text.general.username}
+            {loggedUser.data?.username ?? text.general.username}
           </Typography>
         </Stack>
         <Button

--- a/src/containers/app-container/app-container.tsx
+++ b/src/containers/app-container/app-container.tsx
@@ -1,26 +1,14 @@
 import { type FC, useState } from "react";
 import { Container, type StackProps } from "@mui/material";
 
-import { api } from "~/utils/api.js";
 import { Navbar } from "~/components/navbar/index.js";
 import { styles } from "~/containers/app-container/styles.js";
-import { isVerifiedUser } from "~/utils/user.js";
-
 export const AppContainer: FC<StackProps> = ({ children }) => {
   const [menuIsOpen, setMenuIsOpen] = useState(false);
 
-  const loggedUser = api.user.getLoggedUser.useQuery(undefined, {
-    retry: false,
-  });
-
   return (
     <Container component="main" sx={styles.container}>
-      <Navbar
-        isVerifiedUser={isVerifiedUser(loggedUser.data)}
-        username={loggedUser.data?.username}
-        open={menuIsOpen}
-        setOpen={setMenuIsOpen}
-      />
+      <Navbar open={menuIsOpen} setOpen={setMenuIsOpen} />
       {children}
     </Container>
   );


### PR DESCRIPTION
This pr addresses the following issues:
- [x] navbar username does not update when the main menu is open
- [x] connect/signOut link failed to detect if a verified user was logged in
- [x] example.env const `PLAYERS_PER_MATCH` was set to 2, enabling a single player game