### PR TITLE
feat: store chat history

### DIFF
--- a/migrations/0001_naive_toad.sql
+++ b/migrations/0001_naive_toad.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "bot_busters_match" ADD COLUMN "messages" json DEFAULT '[]'::json NOT NULL;

--- a/migrations/meta/0001_snapshot.json
+++ b/migrations/meta/0001_snapshot.json
@@ -1,0 +1,196 @@
+{
+  "id": "82cafdbe-c760-494f-b5c9-f054eb45b2cc",
+  "prevId": "ad7e300d-50a5-4f41-9767-5771f90314f4",
+  "version": "5",
+  "dialect": "pg",
+  "tables": {
+    "bot_busters_match": {
+      "name": "bot_busters_match",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "room": {
+          "name": "room",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "messages": {
+          "name": "messages",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::json"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "bot_busters_rank": {
+      "name": "bot_busters_rank",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bot_busters_rank_user_id_bot_busters_user_id_fk": {
+          "name": "bot_busters_rank_user_id_bot_busters_user_id_fk",
+          "tableFrom": "bot_busters_rank",
+          "tableTo": "bot_busters_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bot_busters_rank_position_unique": {
+          "name": "bot_busters_rank_position_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "position"
+          ]
+        }
+      }
+    },
+    "bot_busters_user": {
+      "name": "bot_busters_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "username": {
+          "name": "username",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "address": {
+          "name": "address",
+          "type": "varchar(63)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "bot_busters_user_username_unique": {
+          "name": "bot_busters_user_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "username"
+          ]
+        }
+      }
+    },
+    "bot_busters_user_match": {
+      "name": "bot_busters_user_match",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "bot_busters_user_match_user_id_bot_busters_user_id_fk": {
+          "name": "bot_busters_user_match_user_id_bot_busters_user_id_fk",
+          "tableFrom": "bot_busters_user_match",
+          "tableTo": "bot_busters_user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "bot_busters_user_match_match_id_bot_busters_match_id_fk": {
+          "name": "bot_busters_user_match_match_id_bot_busters_match_id_fk",
+          "tableFrom": "bot_busters_user_match",
+          "tableTo": "bot_busters_match",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "id": {
+          "name": "id",
+          "columns": [
+            "user_id",
+            "match_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/migrations/meta/_journal.json
+++ b/migrations/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1705492358521,
       "tag": "0000_minor_bullseye",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1706696639762,
+      "tag": "0001_naive_toad",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/match.ts
+++ b/src/server/db/match.ts
@@ -4,10 +4,10 @@ import {
   usersToMatches,
   type UserToMatch,
 } from "~/server/db/schema.js";
-import { type MatchRoom } from "~/types/index.js";
+import { type StoredChatMessage, type MatchRoom } from "~/types/index.js";
 
 export const insertMatches = async (
-  matches: { id: string; room: MatchRoom }[],
+  matches: { id: string; room: MatchRoom; messages: StoredChatMessage[] }[],
   tx?: BBPgTransaction,
 ) => {
   const dbTx = tx ?? db;
@@ -15,15 +15,11 @@ export const insertMatches = async (
 
   const promises = matches.map(async (match) => {
     const userMatch: UserToMatch[] = match.room.players
-      .filter((player) => {
-        return !player.isBot;
-      })
-      .map((player) => {
-        return {
-          userId: player.userId,
-          matchId: match.id,
-        };
-      });
+      .filter((player) => !player.isBot)
+      .map((player) => ({
+        userId: player.userId,
+        matchId: match.id,
+      }));
     await dbTx.insert(usersToMatches).values(userMatch);
   });
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -12,7 +12,7 @@ import { createInsertSchema } from "drizzle-zod";
 import { type z } from "zod";
 
 import { PUBLIC_KEY_LENGTH } from "~/constants/index.js";
-import { type MatchRoom } from "~/types/index.js";
+import { type StoredChatMessage, type MatchRoom } from "~/types/index.js";
 
 export const bbPgTable = pgTableCreator((name) => `bot_busters_${name}`);
 
@@ -49,6 +49,7 @@ export type Rank = z.infer<typeof rankSchema>;
 export const matches = bbPgTable("match", {
   id: uuid("id").primaryKey(),
   room: json("room").notNull().$type<MatchRoom>(),
+  messages: json("messages").notNull().$type<StoredChatMessage[]>().default([]),
 });
 
 export const usersToMatches = bbPgTable(

--- a/src/server/service/match.ts
+++ b/src/server/service/match.ts
@@ -24,6 +24,7 @@ import {
   type MatchRoom,
   type MatchStage,
   type PlayerType,
+  type StoredChatMessage,
 } from "~/types/index.js";
 import { getRandomInt } from "~/utils/math.js";
 import { matchAchievements } from "~/server/service/achievements.js";
@@ -180,7 +181,7 @@ export class Match {
     }
 
     this._messageCountSinceLastTrigger++;
-    this.messages.push(message);
+    this._messages.push(message);
     ee.emit(matchEvent(this.id), message);
   }
 
@@ -341,6 +342,15 @@ export class Match {
     this._messages = [];
     this._agents.forEach((agent) => agent.cleanup());
     clearInterval(this._intervalId);
+  }
+
+  convertMessages(): StoredChatMessage[] {
+    return this._messages.flatMap((message) => {
+      // TODO: also add host message
+      const player = this._players.find((p) => p.userId === message.sender);
+      if (!player) return [];
+      return { ...message, sender: player.characterId, isBot: !!player.isBot };
+    });
   }
 
   toSerializable(): MatchRoom {

--- a/src/server/service/match.ts
+++ b/src/server/service/match.ts
@@ -346,9 +346,17 @@ export class Match {
 
   convertMessages(): StoredChatMessage[] {
     return this._messages.flatMap((message) => {
-      // TODO: also add host message
+      if (message.sender === "host") {
+        return {
+          ...message,
+          sender: "host",
+          isBot: false,
+        } satisfies StoredChatMessage;
+      }
+
       const player = this._players.find((p) => p.userId === message.sender);
       if (!player) return [];
+
       return { ...message, sender: player.characterId, isBot: !!player.isBot };
     });
   }

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -14,14 +14,14 @@ export const characterIdSchema = z.enum(["1", "2", "3", "4", "5"]);
 export type CharacterId = z.infer<typeof characterIdSchema>;
 
 export const chatMessagePayloadSchema = z.object({
-  sender: z.string().uuid(),
+  sender: z.string().uuid().or(z.literal("host")),
   message: z.string(),
   sentAt: z.number(), // unix time
 });
 export type ChatMessagePayload = z.infer<typeof chatMessagePayloadSchema>;
 
 export const storedChatMessageSchema = z.object({
-  sender: characterIdSchema,
+  sender: characterIdSchema.or(z.literal("host")),
   message: z.string(),
   sentAt: z.number(), // unix time
   isBot: z.boolean(),

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -10,12 +10,23 @@ export interface QueueUpdatePayload {
   queueLength: number;
 }
 
+export const characterIdSchema = z.enum(["1", "2", "3", "4", "5"]);
+export type CharacterId = z.infer<typeof characterIdSchema>;
+
 export const chatMessagePayloadSchema = z.object({
   sender: z.string().uuid(),
   message: z.string(),
   sentAt: z.number(), // unix time
 });
 export type ChatMessagePayload = z.infer<typeof chatMessagePayloadSchema>;
+
+export const storedChatMessageSchema = z.object({
+  sender: characterIdSchema,
+  message: z.string(),
+  sentAt: z.number(), // unix time
+  isBot: z.boolean(),
+});
+export type StoredChatMessage = z.infer<typeof storedChatMessageSchema>;
 
 export const achievementIdSchema = z.enum([
   // Match achievement - perfect score (all votes correct)
@@ -32,9 +43,6 @@ export const achievementIdSchema = z.enum([
   "realHuman",
 ]);
 export type AchievementId = z.infer<typeof achievementIdSchema>;
-
-export const characterIdSchema = z.enum(["1", "2", "3", "4", "5"]);
-export type CharacterId = z.infer<typeof characterIdSchema>;
 
 export const playerSchema = z.object({
   userId: z.string().uuid(),


### PR DESCRIPTION
## Description

Storing chat history in the match table.

## Changes

- Add `messages` column to `match` table
- Substitute user id with character id before storing messages
- Store messages on db at the end of a match