### PR TITLE
feat(achievements): remove Double Agent achievement

### DIFF
--- a/src/assets/text/achievements.ts
+++ b/src/assets/text/achievements.ts
@@ -10,4 +10,6 @@ export const achievements = {
     `${amount} ${amount === 1 ? "Bot" : "Bots"} Busted`,
   humansIdentified: (amount: number) =>
     `${amount} ${amount === 1 ? "Human" : "Humans"} Identified`,
+  humansFooled: (amount: number) =>
+    `${amount} ${amount === 1 ? "Human" : "Humans"} Fooled`,
 };

--- a/src/components/score/score.tsx
+++ b/src/components/score/score.tsx
@@ -1,9 +1,9 @@
-import { type FC } from "react";
 import { Stack, Tooltip, Typography } from "@mui/material";
+import { type FC } from "react";
 
-import { type PlayerType } from "~/types/index.js";
-import { POINTS_ACHIEVEMENTS } from "~/constants/main.js";
 import { text } from "~/assets/text/index.js";
+import { POINTS_ACHIEVEMENTS } from "~/constants/main.js";
+import { type PlayerType } from "~/types/index.js";
 // TODO: decouple from server
 import { matchAchievements } from "~/server/service/achievements.js";
 
@@ -78,7 +78,12 @@ export const Score: FC<ScoreProps> = ({ player }) => {
             score={player.humansBustedScore}
           />
         )}
-
+        {player.humansFooled > 0 && (
+          <ScoreRow
+            title={text.achievements.humansFooled(player.humansFooled)}
+            score={player.humansFooledScore}
+          />
+        )}
         {player.achievements.map((achievement) => {
           const { name, description } = matchAchievements[achievement];
 

--- a/src/constants/main.ts
+++ b/src/constants/main.ts
@@ -24,10 +24,11 @@ export const CHIP_TIMEOUT = 4000;
 
 export const POINTS_BOT_BUSTED = 11;
 export const POINTS_HUMAN_BUSTED = 10;
+export const POINTS_HUMAN_FOOLED = 5;
+
 export const POINTS_ACHIEVEMENTS: Record<AchievementId, number> = {
   dailyStreakCounter: 0,
   goodBust: 5,
-  doubleAgent: 5,
   busterStreak: 9,
   fiveDayStreak: 9,
   firstTimer: 5,

--- a/src/server/service/agent.ts
+++ b/src/server/service/agent.ts
@@ -142,6 +142,8 @@ export class Agent {
       botsBusted: 0,
       totalBotsBusted: 0,
       humansBusted: 0,
+      humansFooled: 0,
+      humansFooledScore: 0,
       botsBustedScore: 0,
       humansBustedScore: 0,
       correctGuesses: 0,

--- a/src/server/service/match.ts
+++ b/src/server/service/match.ts
@@ -10,6 +10,7 @@ import {
   POINTS_ACHIEVEMENTS,
   POINTS_BOT_BUSTED,
   POINTS_HUMAN_BUSTED,
+  POINTS_HUMAN_FOOLED,
   VOTING_TIME_MS,
 } from "~/constants/index.js";
 import { ee, matchEvent } from "~/server/api/match-maker.js";
@@ -179,8 +180,10 @@ export class Match {
       botsBusted: 0,
       totalBotsBusted: 0,
       humansBusted: 0,
+      humansFooled: 0,
       botsBustedScore: 0,
       humansBustedScore: 0,
+      humansFooledScore: 0,
       correctGuesses: 0,
       achievements: [],
     };
@@ -287,9 +290,11 @@ export class Match {
       let correctGuesses = 0;
       let botsBusted = 0;
       let humansBusted = 0;
+      let humansFooled = 0;
       let score = 0;
       let botsBustedScore = 0;
       let humansBustedScore = 0;
+      let humansFooledScore = 0;
 
       const otherPlayers = this.players.filter(
         (p) => p.userId !== player.userId,
@@ -300,7 +305,15 @@ export class Match {
 
       otherPlayers.forEach((p) => {
         const isVoted = player.votes!.includes(p.userId);
+        const fooledHuman = p.votes?.includes(player.userId);
+
         const hasGuessed = p.isBot ? isVoted : !isVoted;
+
+        if (fooledHuman) {
+          humansFooled += 1;
+          score += POINTS_HUMAN_FOOLED;
+          humansFooledScore += POINTS_HUMAN_FOOLED;
+        }
 
         if (hasGuessed) {
           correctGuesses += 1;
@@ -350,8 +363,10 @@ export class Match {
         correctGuesses,
         botsBusted,
         humansBusted,
+        humansFooled,
         botsBustedScore,
         humansBustedScore,
+        humansFooledScore,
       };
     });
 

--- a/src/types/match.ts
+++ b/src/types/match.ts
@@ -33,8 +33,6 @@ export const achievementIdSchema = z.enum([
   "dailyStreakCounter",
   // Match achievement - perfect score (all votes correct)
   "goodBust",
-  // Match achievement - two people selected you as a bot
-  "doubleAgent",
   // Day achievement - successfully bust all bots 3 consecutive games
   "busterStreak",
   // One time achievement - player plays his first game
@@ -59,8 +57,10 @@ export const playerSchema = z.object({
   botsBusted: z.number(),
   totalBotsBusted: z.number(),
   humansBusted: z.number(),
+  humansFooled: z.number(),
   botsBustedScore: z.number(),
   humansBustedScore: z.number(),
+  humansFooledScore: z.number(),
   correctGuesses: z.number(),
   votes: z.array(z.string().uuid()).optional(), // array of voted ids
   isVerified: z.boolean().optional(),


### PR DESCRIPTION
## Description

This PR Removes the achievements Double Agent. Now you get 5 points for every human that guessed you as a bot. 
 
## Related Issues

closes #306 

## Changes Made

- [BE] Removed achievement
- [BE] Introduced new logic for checking if other player guessed you as a bot