### PR TITLE
Bug: Added delay between each bot load to the queue

### DIFF
--- a/src/components/lobby-character-loader/lobby-character-loader.tsx
+++ b/src/components/lobby-character-loader/lobby-character-loader.tsx
@@ -32,7 +32,7 @@ export const LobbyCharacterLoader: FC<Props> = ({
           if (!activatedCharacters.has(i)) {
             setActivatedCharacters((prevSet) => new Set(prevSet).add(i));
           }
-          const delay = getRandomInt(280, 380);
+          const delay = getRandomInt({ min: 280, max: 380 });
           await wait(delay);
         }
       };

--- a/src/components/lobby-character-loader/lobby-character-loader.tsx
+++ b/src/components/lobby-character-loader/lobby-character-loader.tsx
@@ -5,9 +5,10 @@ import { CHARACTERS, DEFAULT_MAX_PLAYERS_PER_ROOM } from "~/constants/index.js";
 import { text } from "~/assets/text/index.js";
 import { LobbyProgressBar } from "~/components/lobby-progress-bar/index.js";
 import { HostAvatar } from "~/assets/characters/index.js";
+import { wait } from "~/utils/timer.js";
+import { getRandomInt } from "~/utils/math.js";
 import { theme } from "~/styles/theme.js";
 import { styles } from "./styles.js";
-import { wait } from "~/utils/timer.js";
 
 interface Props {
   playerQueuePosition: number;
@@ -31,7 +32,8 @@ export const LobbyCharacterLoader: FC<Props> = ({
           if (!activatedCharacters.has(i)) {
             setActivatedCharacters((prevSet) => new Set(prevSet).add(i));
           }
-          await wait(350);
+          const delay = getRandomInt(280, 380);
+          await wait(delay);
         }
       };
 

--- a/src/components/lobby-character-loader/lobby-character-loader.tsx
+++ b/src/components/lobby-character-loader/lobby-character-loader.tsx
@@ -7,14 +7,13 @@ import { LobbyProgressBar } from "~/components/lobby-progress-bar/index.js";
 import { HostAvatar } from "~/assets/characters/index.js";
 import { theme } from "~/styles/theme.js";
 import { styles } from "./styles.js";
+import { wait } from "~/utils/timer.js";
 
 interface Props {
   playerQueuePosition: number;
   queueLength: number;
   matchReady: boolean;
 }
-
-const MATCH_READY_SET = new Set<number>([1, 2, 3, 4, 5]);
 
 export const LobbyCharacterLoader: FC<Props> = ({
   playerQueuePosition,
@@ -27,26 +26,40 @@ export const LobbyCharacterLoader: FC<Props> = ({
 
   useEffect(() => {
     if (matchReady) {
-      setActivatedCharacters(MATCH_READY_SET);
-      return;
-    }
+      const addCharactersWithDelay = async () => {
+        for (let i = 1; i <= DEFAULT_MAX_PLAYERS_PER_ROOM; i++) {
+          if (!activatedCharacters.has(i)) {
+            setActivatedCharacters((prevSet) => new Set(prevSet).add(i));
+          }
+          await wait(350);
+        }
+      };
 
+      void addCharactersWithDelay();
+    } else {
+      const newSet = new Set<number>();
+      if (
+        playerQueuePosition !== 0 &&
+        playerQueuePosition <= DEFAULT_MAX_PLAYERS_PER_ROOM
+      ) {
+        const upperLimit = Math.min(queueLength, DEFAULT_MAX_PLAYERS_PER_ROOM);
+        for (let i = 1; i <= upperLimit; i++) {
+          newSet.add(i);
+        }
+      }
+      setActivatedCharacters(newSet);
+    }
+  }, [matchReady, playerQueuePosition, queueLength]);
+
+  useEffect(() => {
     if (
-      playerQueuePosition === 0 ||
-      playerQueuePosition > DEFAULT_MAX_PLAYERS_PER_ROOM
+      !matchReady &&
+      (playerQueuePosition === 0 ||
+        playerQueuePosition > DEFAULT_MAX_PLAYERS_PER_ROOM)
     ) {
       setActivatedCharacters(new Set());
-      return;
     }
-
-    const newSet = new Set<number>();
-    const upperLimit = Math.min(queueLength, DEFAULT_MAX_PLAYERS_PER_ROOM);
-    for (let i = 1; i <= upperLimit; i++) {
-      newSet.add(i);
-    }
-
-    setActivatedCharacters(newSet);
-  }, [matchReady, playerQueuePosition, queueLength]);
+  }, [matchReady, playerQueuePosition]);
 
   return (
     <Stack sx={styles.container}>

--- a/src/pages/lobby.tsx
+++ b/src/pages/lobby.tsx
@@ -13,6 +13,7 @@ const Lobby: FC = () => {
   const { showBoundary } = useErrorBoundary();
   const { push } = useRouter();
   const join = api.lobby.join.useMutation();
+
   const [lobbyQueue, setLobbyQueue] = useState({
     playerQueuePosition: 0,
     queueLength: 0,
@@ -49,7 +50,6 @@ const Lobby: FC = () => {
       e instanceof Error
         ? console.error(`[${errorMessage.match.general}]: ${e.message}`, e)
         : console.error(e);
-
       showBoundary(errorMessage.match.general);
     },
   });


### PR DESCRIPTION
## Changes

- [x] If match is set for waiting for N amount of humans, players can clearly see that after the humans have connected to the lobby, the rest of the slots get filled immediately. This hints the amount of bots in the chat.
The order of the characters appearing in the Lobby is already random